### PR TITLE
basic support for loading `values.yaml` for a Solution

### DIFF
--- a/src/bin/solsa.ts
+++ b/src/bin/solsa.ts
@@ -57,6 +57,8 @@ if (argv._[0] === 'help') {
   let solution: any
 
   try {
+    const solutionDir = path.dirname(require.resolve(file))
+    require('solsa').loadSolutionConfig(solutionDir)
     solution = require(file)
     if (!solution.runCommand) throw new Error(`Module '${file}' does not export a SolSA solution`)
     solution.runCommand(args, solution)

--- a/src/solution.ts
+++ b/src/solution.ts
@@ -16,6 +16,10 @@
 
 import { dynamic } from './helpers'
 import { runCommand } from './cli'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as yaml from 'js-yaml'
+import { file } from 'tmp'
 
 /**
  * Solution is the root of SolSA's class hierarchy. A solution is either a SolSA
@@ -139,4 +143,26 @@ export class RawKubernetesResource extends KubernetesResource {
     super({ apiVersion: properties.apiVersion, kind: properties.kind })
     Object.assign(this, properties)
   }
+}
+
+// Support for loading an optional values.yaml for the top-level solution (approx a values.yaml for a Helm chart)
+let _solutionConfig: dynamic = {}
+export function loadSolutionConfig (solutionDir: string) {
+  const valuesFile = path.join(solutionDir, 'values.yaml')
+  if (fs.existsSync(valuesFile)) {
+    try {
+      _solutionConfig = yaml.safeLoad(fs.readFileSync(valuesFile).toString())
+    } catch (err) {
+      console.error('Error loading yaml from file ${valuesFile}')
+      throw err
+    }
+  }
+}
+
+/**
+ * Access the contents of the optional values.yaml file co-located with
+ * the top-level Solution being processed.
+ */
+export function getSolutionConfig (): dynamic {
+  return _solutionConfig
 }


### PR DESCRIPTION
If there is a values.yaml in the same directory as the SolSA
Solution file being processed, then load the contents of that
file and make it available via solsa.getSolutionConfig()